### PR TITLE
Close figure after plotting + few fixes

### DIFF
--- a/predicu/data.py
+++ b/predicu/data.py
@@ -65,10 +65,7 @@ def load_all_data(
     if cache and os.path.isfile(DATA_PATHS["icubam_cache"]):
         return pd.read_hdf(DATA_PATHS["icubam_cache"])
     pre_icubam = load_pre_icubam_data()
-    if icubam_data is not None:
-        icubam = icubam_data
-    else:
-        icubam = load_icubam_data(api_key=api_key)
+    icubam = load_icubam_data(data=icubam_data, api_key=api_key)
     dates_in_both = set(icubam.date.unique()) & set(pre_icubam.date.unique())
     pre_icubam = pre_icubam.loc[~pre_icubam.date.isin(dates_in_both)]
     d = pd.concat([pre_icubam, icubam])
@@ -83,8 +80,10 @@ def load_all_data(
     return d
 
 
-def load_icubam_data(api_key):
-    if api_key is None:
+def load_icubam_data(data=None, api_key=None):
+    if data is not None:
+        d = data
+    elif api_key is None:
         d = load_data_file(DATA_PATHS["icubam"])
     else:
         url = (

--- a/predicu/plot/__init__.py
+++ b/predicu/plot/__init__.py
@@ -4,6 +4,7 @@ import os
 from typing import List, Optional
 
 import matplotlib
+import matplotlib.pyplot as plt
 import matplotlib.style
 import numpy as np
 import scipy
@@ -128,6 +129,7 @@ def plot(plot_name, data, **plot_args):
         )
     else:
         raise ValueError(f"Unknown output type: {output_type}")
+    plt.close(fig)
 
 
 def generate_plots(


### PR DESCRIPTION
Close figures after it is rendered to avoid,
```
RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).
```

Also a few leftover fixes for https://github.com/icubam/predicu/pull/7